### PR TITLE
rename project title to "Django MongoDB Backend"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MongoDB backend for Django
+# Django MongoDB Backend
 
 This backend is currently in development and is not advised for Production workflows. Backwards incompatible
 changes may be made without notice. We welcome your feedback as we continue to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "django-mongodb-backend"
 dynamic = ["version", "dependencies"]
-description = "MongoDB backend for Django"
+description = "Django MongoDB Backend"
 readme = "README.md"
 license = {file="LICENSE"}
 requires-python = ">=3.10"


### PR DESCRIPTION
I believe the team wants to use these three words everywhere.