### PR TITLE
Add 8.0 and Auth + SSL Testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -38,22 +38,12 @@ functions:
       params:
         binary: bash
         script: |
-          ls -l ${DRIVERS_TOOLS}/
+          find ${DRIVERS_TOOLS}
     - command: shell.exec
       params:
         binary: bash
         script: |
-          ls -l ${DRIVERS_TOOLS}/.evergreen/
-    - command: shell.exec
-      params:
-        binary: bash
-        script: |
-          ls -l ${DRIVERS_TOOLS}/.evergreen/orchestration/
-    - command: shell.exec
-      params:
-        binary: bash
-        script: |
-          ls -l .evergreen/
+          find .
     - command: expansions.update
       params:
         file: ${DRIVERS_TOOLS}/.evergreen/orchestration/mo-expansion.yml

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -36,7 +36,7 @@ functions:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:
-        file: ${DRIVERS_TOOLS}/expansion.yml
+        file: ${DRIVERS_TOOLS}/mo-expansion.yml
 
 
   "run unit tests":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -34,19 +34,9 @@ functions:
         add_expansions_to_env: true
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
-    - command: shell.exec
-      params:
-        binary: bash
-        script: |
-          find ${DRIVERS_TOOLS}
-    - command: shell.exec
-      params:
-        binary: bash
-        script: |
-          find .
     - command: expansions.update
       params:
-        file: ${DRIVERS_TOOLS}/.evergreen/orchestration/mo-expansion.yml
+        file: mo-expansion.yml
 
 
   "run unit tests":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -34,6 +34,11 @@ functions:
         add_expansions_to_env: true
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+    - command: shell.exec
+      params:
+        binary: bash
+        run: |
+          tree ${DRIVERS_TOOLS}/
     - command: expansions.update
       params:
         file: ${DRIVERS_TOOLS}/.evergreen/orchestration/mo-expansion.yml

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -36,7 +36,7 @@ functions:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:
-        file: ${DRIVERS_TOOLS}/.evergreen/mo-expansion.yml
+        file: ${DRIVERS_TOOLS}/.evergreen/orchestration/mo-expansion.yml
 
 
   "run unit tests":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -107,4 +107,3 @@ buildvariants:
     SSL: "ssl"
   tasks:
   - name: run-tests
-

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -31,11 +31,6 @@ functions:
     - command: subprocess.exec
       params:
         binary: bash
-        env:
-          MONGODB_VERSION: "5.0"
-          TOPOLOGY: server
-          AUTH: "noauth"
-          SSL: "nossl"
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
 
@@ -69,8 +64,47 @@ tasks:
     - func: "run unit tests"
 
 buildvariants:
-- name: tests
-  display_name: Run Tests
+- name: tests-5-noauth-nossl
+  display_name: Run Tests 5.0 NoAuth NoSSL
   run_on: rhel87-small
+  expansions:
+    MONGODB_VERSION: "5.0"
+    TOPOLOGY: server
+    AUTH: "noauth"
+    SSL: "nossl"
   tasks:
   - name: run-tests
+
+- name: tests-5-auth-ssl
+  display_name: Run Tests 5.0 Auth SSL
+  run_on: rhel87-small
+  expansions:
+    MONGODB_VERSION: "5.0"
+    TOPOLOGY: server
+    AUTH: "auth"
+    SSL: "ssl"
+  tasks:
+  - name: run-tests
+
+- name: tests-8-noauth-nossl
+  display_name: Run Tests 8.0 NoAuth NoSSL
+  run_on: rhel87-small
+  expansions:
+    MONGODB_VERSION: "8.0"
+    TOPOLOGY: server
+    AUTH: "noauth"
+    SSL: "nossl"
+  tasks:
+  - name: run-tests
+
+- name: tests-8-noauth-nossl
+  display_name: Run Tests 8.0 Auth SSL
+  run_on: rhel87-small
+  expansions:
+    MONGODB_VERSION: "8.0"
+    TOPOLOGY: server
+    AUTH: "auth"
+    SSL: "ssl"
+  tasks:
+  - name: run-tests
+

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -97,7 +97,7 @@ buildvariants:
   tasks:
   - name: run-tests
 
-- name: tests-8-noauth-nossl
+- name: tests-8-auth-ssl
   display_name: Run Tests 8.0 Auth SSL
   run_on: rhel87-small
   expansions:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -34,10 +34,14 @@ functions:
         add_expansions_to_env: true
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+    - command: shell.exec
+      params:
+        binary: bash
+        script: |
+          cat mo-expansion.yml
     - command: expansions.update
       params:
         file: mo-expansion.yml
-
 
   "run unit tests":
     - command: subprocess.exec
@@ -64,51 +68,51 @@ post:
   - func: teardown
 
 tasks:
-- name: run-tests
-  commands:
-    - func: "run unit tests"
+  - name: run-tests
+    commands:
+      - func: "run unit tests"
 
 buildvariants:
-- name: tests-5-noauth-nossl
-  display_name: Run Tests 5.0 NoAuth NoSSL
-  run_on: rhel87-small
-  expansions:
-    MONGODB_VERSION: "5.0"
-    TOPOLOGY: server
-    AUTH: "noauth"
-    SSL: "nossl"
-  tasks:
-  - name: run-tests
+  - name: tests-5-noauth-nossl
+    display_name: Run Tests 5.0 NoAuth NoSSL
+    run_on: rhel87-small
+    expansions:
+      MONGODB_VERSION: "5.0"
+      TOPOLOGY: server
+      AUTH: "noauth"
+      SSL: "nossl"
+    tasks:
+      - name: run-tests
 
-- name: tests-5-auth-ssl
-  display_name: Run Tests 5.0 Auth SSL
-  run_on: rhel87-small
-  expansions:
-    MONGODB_VERSION: "5.0"
-    TOPOLOGY: server
-    AUTH: "auth"
-    SSL: "ssl"
-  tasks:
-  - name: run-tests
+  - name: tests-5-auth-ssl
+    display_name: Run Tests 5.0 Auth SSL
+    run_on: rhel87-small
+    expansions:
+      MONGODB_VERSION: "5.0"
+      TOPOLOGY: server
+      AUTH: "auth"
+      SSL: "ssl"
+    tasks:
+      - name: run-tests
 
-- name: tests-8-noauth-nossl
-  display_name: Run Tests 8.0 NoAuth NoSSL
-  run_on: rhel87-small
-  expansions:
-    MONGODB_VERSION: "8.0"
-    TOPOLOGY: server
-    AUTH: "noauth"
-    SSL: "nossl"
-  tasks:
-  - name: run-tests
+  - name: tests-8-noauth-nossl
+    display_name: Run Tests 8.0 NoAuth NoSSL
+    run_on: rhel87-small
+    expansions:
+      MONGODB_VERSION: "8.0"
+      TOPOLOGY: server
+      AUTH: "noauth"
+      SSL: "nossl"
+    tasks:
+      - name: run-tests
 
-- name: tests-8-auth-ssl
-  display_name: Run Tests 8.0 Auth SSL
-  run_on: rhel87-small
-  expansions:
-    MONGODB_VERSION: "8.0"
-    TOPOLOGY: server
-    AUTH: "auth"
-    SSL: "ssl"
-  tasks:
-  - name: run-tests
+  - name: tests-8-auth-ssl
+    display_name: Run Tests 8.0 Auth SSL
+    run_on: rhel87-small
+    expansions:
+      MONGODB_VERSION: "8.0"
+      TOPOLOGY: server
+      AUTH: "auth"
+      SSL: "ssl"
+    tasks:
+      - name: run-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -38,7 +38,22 @@ functions:
       params:
         binary: bash
         script: |
-          tree ${DRIVERS_TOOLS}/
+          ls -l ${DRIVERS_TOOLS}/
+    - command: shell.exec
+      params:
+        binary: bash
+        script: |
+          ls -l ${DRIVERS_TOOLS}/.evergreen/
+    - command: shell.exec
+      params:
+        binary: bash
+        script: |
+          ls -l ${DRIVERS_TOOLS}/.evergreen/orchestration/
+    - command: shell.exec
+      params:
+        binary: bash
+        script: |
+          ls -l .evergreen/
     - command: expansions.update
       params:
         file: ${DRIVERS_TOOLS}/.evergreen/orchestration/mo-expansion.yml

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -36,7 +36,7 @@ functions:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     - command: expansions.update
       params:
-        file: ${DRIVERS_TOOLS}/mo-expansion.yml
+        file: ${DRIVERS_TOOLS}/.evergreen/mo-expansion.yml
 
 
   "run unit tests":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -31,6 +31,7 @@ functions:
     - command: subprocess.exec
       params:
         binary: bash
+        add_expansions_to_env: true
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -34,6 +34,10 @@ functions:
         add_expansions_to_env: true
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+    - command: expansions.update
+      params:
+        file: ${DRIVERS_TOOLS}/expansion.yml
+
 
   "run unit tests":
     - command: subprocess.exec
@@ -41,7 +45,7 @@ functions:
       params:
         binary: bash
         working_dir: "src"
-        include_expansions_in_env: ["DRIVERS_TOOLS"]
+        include_expansions_in_env: ["DRIVERS_TOOLS", "MONGODB_URI"]
         args:
           - ./.evergreen/run-tests.sh
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -34,11 +34,6 @@ functions:
         add_expansions_to_env: true
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
-    - command: shell.exec
-      params:
-        binary: bash
-        script: |
-          cat mo-expansion.yml
     - command: expansions.update
       params:
         file: mo-expansion.yml

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -37,7 +37,7 @@ functions:
     - command: shell.exec
       params:
         binary: bash
-        run: |
+        script: |
           tree ${DRIVERS_TOOLS}/
     - command: expansions.update
       params:

--- a/.github/workflows/mongodb_settings.py
+++ b/.github/workflows/mongodb_settings.py
@@ -5,6 +5,10 @@ from django_mongodb_backend import parse_uri
 
 PARSED_URI = parse_uri(os.getenv("MONGODB_URI")) if os.getenv("MONGODB_URI") else {}
 
+# Temporary fix for https://github.com/mongodb-labs/mongo-orchestration/issues/268
+if "USER" in PARSED_URI and "PASSWORD" in PARSED_URI:
+    PARSED_URI["OPTIONS"]["tls"] = True
+
 DATABASES = {
     "default": {
         **PARSED_URI,
@@ -17,7 +21,7 @@ DATABASES = {
         "NAME": "djangotests-other",
     },
 }
-print(DATABASES)
+
 DEFAULT_AUTO_FIELD = "django_mongodb_backend.fields.ObjectIdAutoField"
 PASSWORD_HASHERS = ("django.contrib.auth.hashers.MD5PasswordHasher",)
 SECRET_KEY = "django_tests_secret_key"

--- a/.github/workflows/mongodb_settings.py
+++ b/.github/workflows/mongodb_settings.py
@@ -1,9 +1,18 @@
+import os
+
+from django_mongodb_backend import parse_uri
+
+PARSED_URI = parse_uri(os.getenv("MONGODB_URI")) if os.getenv("MONGODB_URI") else {}
+
+
 DATABASES = {
     "default": {
+        **PARSED_URI,
         "ENGINE": "django_mongodb_backend",
         "NAME": "djangotests",
     },
     "other": {
+        **PARSED_URI,
         "ENGINE": "django_mongodb_backend",
         "NAME": "djangotests-other",
     },

--- a/.github/workflows/mongodb_settings.py
+++ b/.github/workflows/mongodb_settings.py
@@ -2,7 +2,6 @@ import os
 
 from django_mongodb_backend import parse_uri
 
-
 PARSED_URI = parse_uri(os.getenv("MONGODB_URI")) if os.getenv("MONGODB_URI") else {}
 
 # Temporary fix for https://github.com/mongodb-labs/mongo-orchestration/issues/268

--- a/.github/workflows/mongodb_settings.py
+++ b/.github/workflows/mongodb_settings.py
@@ -2,8 +2,11 @@ import os
 
 from django_mongodb_backend import parse_uri
 
+
 PARSED_URI = parse_uri(os.getenv("MONGODB_URI")) if os.getenv("MONGODB_URI") else {}
 
+if not PARSED_URI:
+    print("MONGODB_URI not found; please check if environment variable set")
 
 DATABASES = {
     "default": {

--- a/.github/workflows/mongodb_settings.py
+++ b/.github/workflows/mongodb_settings.py
@@ -5,8 +5,9 @@ from django_mongodb_backend import parse_uri
 PARSED_URI = parse_uri(os.getenv("MONGODB_URI")) if os.getenv("MONGODB_URI") else {}
 
 # Temporary fix for https://github.com/mongodb-labs/mongo-orchestration/issues/268
-if "USER" in PARSED_URI and "PASSWORD" in PARSED_URI:
+if PARSED_URI["USER"] and PARSED_URI["PASSWORD"]:
     PARSED_URI["OPTIONS"]["tls"] = True
+    PARSED_URI["OPTIONS"]["tlsAllowInvalidCertificates"] = True
 
 DATABASES = {
     "default": {

--- a/.github/workflows/mongodb_settings.py
+++ b/.github/workflows/mongodb_settings.py
@@ -5,9 +5,8 @@ from django_mongodb_backend import parse_uri
 PARSED_URI = parse_uri(os.getenv("MONGODB_URI")) if os.getenv("MONGODB_URI") else {}
 
 # Temporary fix for https://github.com/mongodb-labs/mongo-orchestration/issues/268
-if PARSED_URI["USER"] and PARSED_URI["PASSWORD"]:
-    PARSED_URI["OPTIONS"]["tls"] = True
-    PARSED_URI["OPTIONS"]["tlsAllowInvalidCertificates"] = True
+if PARSED_URI.get("USER") and PARSED_URI.get("PASSWORD"):
+    PARSED_URI["OPTIONS"].update({"tls": True, "tlsAllowInvalidCertificates": True})
 
 DATABASES = {
     "default": {

--- a/.github/workflows/mongodb_settings.py
+++ b/.github/workflows/mongodb_settings.py
@@ -2,24 +2,27 @@ import os
 
 from django_mongodb_backend import parse_uri
 
-PARSED_URI = parse_uri(os.getenv("MONGODB_URI")) if os.getenv("MONGODB_URI") else {}
+if mongodb_uri := os.getenv("MONGODB_URI"):
+    db_settings = parse_uri(mongodb_uri)
 
-# Temporary fix for https://github.com/mongodb-labs/mongo-orchestration/issues/268
-if PARSED_URI.get("USER") and PARSED_URI.get("PASSWORD"):
-    PARSED_URI["OPTIONS"].update({"tls": True, "tlsAllowInvalidCertificates": True})
-
-DATABASES = {
-    "default": {
-        **PARSED_URI,
-        "ENGINE": "django_mongodb_backend",
-        "NAME": "djangotests",
-    },
-    "other": {
-        **PARSED_URI,
-        "ENGINE": "django_mongodb_backend",
-        "NAME": "djangotests-other",
-    },
-}
+    # Workaround for https://github.com/mongodb-labs/mongo-orchestration/issues/268
+    if db_settings["USER"] and db_settings["PASSWORD"]:
+        db_settings.update({"tls": True, "tlsAllowInvalidCertificates": True})
+    DATABASES = {
+        "default": {**db_settings, "NAME": "djangotests"},
+        "other": {**db_settings, "NAME": "djangotests-other"},
+    }
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django_mongodb_backend",
+            "NAME": "djangotests",
+        },
+        "other": {
+            "ENGINE": "django_mongodb_backend",
+            "NAME": "djangotests-other",
+        },
+    }
 
 DEFAULT_AUTO_FIELD = "django_mongodb_backend.fields.ObjectIdAutoField"
 PASSWORD_HASHERS = ("django.contrib.auth.hashers.MD5PasswordHasher",)

--- a/.github/workflows/mongodb_settings.py
+++ b/.github/workflows/mongodb_settings.py
@@ -7,7 +7,7 @@ if mongodb_uri := os.getenv("MONGODB_URI"):
 
     # Workaround for https://github.com/mongodb-labs/mongo-orchestration/issues/268
     if db_settings["USER"] and db_settings["PASSWORD"]:
-        db_settings.update({"tls": True, "tlsAllowInvalidCertificates": True})
+        db_settings["OPTIONS"].update({"tls": True, "tlsAllowInvalidCertificates": True})
     DATABASES = {
         "default": {**db_settings, "NAME": "djangotests"},
         "other": {**db_settings, "NAME": "djangotests-other"},

--- a/.github/workflows/mongodb_settings.py
+++ b/.github/workflows/mongodb_settings.py
@@ -5,9 +5,6 @@ from django_mongodb_backend import parse_uri
 
 PARSED_URI = parse_uri(os.getenv("MONGODB_URI")) if os.getenv("MONGODB_URI") else {}
 
-if not PARSED_URI:
-    print("MONGODB_URI not found; please check if environment variable set")
-
 DATABASES = {
     "default": {
         **PARSED_URI,
@@ -20,6 +17,7 @@ DATABASES = {
         "NAME": "djangotests-other",
     },
 }
+print(DATABASES)
 DEFAULT_AUTO_FIELD = "django_mongodb_backend.fields.ObjectIdAutoField"
 PASSWORD_HASHERS = ("django.contrib.auth.hashers.MD5PasswordHasher",)
 SECRET_KEY = "django_tests_secret_key"


### PR DESCRIPTION
Adding tests: 
* MongoDB SERVER Version 8.0
* Auth SSL

This creates 4 test variants total:
* 5.0 -- NoAuth NoSSL
* 5.0 -- Auth SSL
* 8.0 -- NoAuth NoSSL
* 8.0 -- Auth SSL

Acceptance Criteria:
EVG tests pass