### PR TITLE
fix persistent connections

### DIFF
--- a/django_mongodb_backend/base.py
+++ b/django_mongodb_backend/base.py
@@ -187,7 +187,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         pass
 
     def set_autocommit(self, autocommit, force_begin_transaction_with_broken_autocommit=False):
-        pass
+        self.autocommit = autocommit
 
     def close(self):
         super().close()

--- a/tests/backend_/test_base.py
+++ b/tests/backend_/test_base.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connection
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 from django_mongodb_backend.base import DatabaseWrapper
 
@@ -12,3 +12,12 @@ class DatabaseWrapperTests(SimpleTestCase):
         msg = 'settings.DATABASES is missing the "NAME" value.'
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             DatabaseWrapper(settings).get_connection_params()
+
+
+class DatabaseWrapperConnectionTests(TestCase):
+    def test_set_autocommit(self):
+        self.assertIs(connection.get_autocommit(), True)
+        connection.set_autocommit(False)
+        self.assertIs(connection.get_autocommit(), False)
+        connection.set_autocommit(True)
+        self.assertIs(connection.get_autocommit(), True)


### PR DESCRIPTION
Without autocommit set, BaseDatabaseWrapper.close_if_unusable_or_obsolete() short-circuits early and always closes the connection after each request.