### PR TITLE
Add @async_unsafe to DatabaseWrapper methods as needed

### DIFF
--- a/django_mongodb_backend/base.py
+++ b/django_mongodb_backend/base.py
@@ -3,6 +3,7 @@ import os
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.base.base import BaseDatabaseWrapper
+from django.utils.asyncio import async_unsafe
 from pymongo.collection import Collection
 from pymongo.driver_info import DriverInfo
 from pymongo.mongo_client import MongoClient
@@ -172,6 +173,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             **settings_dict["OPTIONS"],
         }
 
+    @async_unsafe
     def get_new_connection(self, conn_params):
         return MongoClient(**conn_params, driver=self._driver_info())
 
@@ -189,11 +191,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def set_autocommit(self, autocommit, force_begin_transaction_with_broken_autocommit=False):
         pass
 
+    @async_unsafe
     def close(self):
         super().close()
         with contextlib.suppress(AttributeError):
             del self.database
 
+    @async_unsafe
     def cursor(self):
         return Cursor()
 


### PR DESCRIPTION
This follows [the pattern of Django's built-in backends](https://github.com/django/django/commit/a415ce70bef6d91036b00dd2c8544aed7aeeaaed).

As far as I know, no work is needed to support [async ORM queries](https://docs.djangoproject.com/en/dev/topics/async/#queries-the-orm). The work for [async query support](https://github.com/django/django/commit/58b27e0dbb3d31ca1438790870b2b51ecdb10500) didn't require any changes to the built-in database backends.

I tested async queries with this backend in a toy project and all seemed to work fine.